### PR TITLE
add SecurityOptions to Docker::info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "shiplift"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["softprops <d.tangren@gmail.com>"]
 description = "A Rust interface for maneuvering Docker containers"
 documentation = "https://softprops.github.io/shiplift"

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -373,6 +373,7 @@ pub struct Info {
     pub Name: String,
     pub OperatingSystem: String,
     // pub RegistryConfig:???
+    pub SecurityOptions: Vec<String>,
     pub SwapLimit: bool,
     pub SystemTime: Option<String>,
 }


### PR DESCRIPTION
## What?

add `SecurityOptions` to Docker::info

## Why?

So one can programmatically determine what security options like `selinux` are present from the Docker::info interface.

```rust
extern crate shiplift;

use shiplift::Docker;

fn main() {
    let docker = Docker::new();
    println!("info {:?}", docker.info().unwrap().SecurityOptions);
    // info ["name=seccomp,profile=default"]
}

```